### PR TITLE
Added obese fatality rate

### DIFF
--- a/ABMC19/Agents/Actions/Progression/progressionCheck.py
+++ b/ABMC19/Agents/Actions/Progression/progressionCheck.py
@@ -2,6 +2,9 @@ import random
 from ABMC19.Agents.Actions.Progression.removeAgentFromModel import removeAgentFromModel
 
 def selfCheck(agent):
+    bmi = random.normalvariate(27.5,7.5) # Normal distribution with mean as 27.5 and abritary standard deviation from (mean - potentially fatal bmi)
+    if bmi > 35:
+        agent.obese = True
     tsi = agent.ticksSinceInfection
     if agent.infected == True:
         agent.ticksSinceInfection += 1
@@ -18,7 +21,7 @@ def selfCheck(agent):
 
             cfr = random.uniform(0,1) #cfr is case fatality rate, im going of an avg of 5% cases result in death (however this can be alterable)
 
-            if cfr < 0.05: #5% of cases will die
+            if cfr < 0.05 or (cfr < 0.11 and agent.obese == True): #5% of cases will die or if agent is obese 11% will die
                 agent.model.deaths += 1
                 agent.dead = True
                 removeAgentFromModel(agent)

--- a/ABMC19/Agents/agent.py
+++ b/ABMC19/Agents/agent.py
@@ -10,6 +10,7 @@ class covAgent(Agent):
         self.dead = False
         self.infected = False
         self.immune = False
+        self.obese = False
         self.ticksSinceInfection = 0 #i will say each tick is a day, this is only activated once the agent is infected
 
         #disease progression


### PR DESCRIPTION
- `self.obese` attribute added to the covAgent(Agent) class initially set to false.

- BMI is calculated from a standard deviation with more details in the shared word doc in progressionCheck.py

- The case fatality rate now takes into account obesity and adjusts accordingly.

- I also feel the `or (cfr < 0.11 and agent.obese == True)` in line 24 of progressionCheck.py feel like a bit of a hack so you can make changes however you like.

- Before deaths usually summed to around 10. After few runs the total deaths now usually are around 20-25.